### PR TITLE
add grades overview

### DIFF
--- a/app/assets/stylesheets/includes/tweaks.scss
+++ b/app/assets/stylesheets/includes/tweaks.scss
@@ -45,3 +45,8 @@ a[href*="//"]:after
 	font-family: "FontAwesome";
 	font-size:10pt;
 }
+
+#overview table td
+{
+	text-align: center;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -35,7 +35,7 @@ class HomeController < ApplicationController
 		@final_grade_name = @final_grade_names[0]
 
 		# determine the categories, ignore weight 0
-		@overview = Hash.new
+		@overview = {}
 		Settings.grading['calculation'][@final_grade_name].each_pair do |category, weight|
 			if weight != 0
 				@overview[category] = []

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -59,7 +59,7 @@ class HomeController < ApplicationController
 		@subgrades = @subgrades.uniq
 
 		# convert grades to an easy-to-use format
-		@grades_by_pset = Hash[@grades.collect { |item| [item.pset.name, item] } ]
+		@grades_by_pset = @grades.to_h { |item| [item.pset.name, item] }
 
 	end
 	

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -40,7 +40,7 @@ class HomeController < ApplicationController
 
 			# determine subgrades
 			@overview[category]['submits'].each_pair do |submit, weight|
-				@subgrades += Settings.grading['grades'][submit]['subgrades'].keys
+				@subgrades += Settings.grading['grades'][submit]['subgrades'].keys if !Settings.grading['grades'][submit]['hide_subgrades']
 			end 
 		end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -33,19 +33,23 @@ class HomeController < ApplicationController
 		# determine the categories to show
 		@overview = Settings.grading.select { |category, value| value['show_progress'] }
 
-		@subgrades = []
+		@subgrades = {}
+		@show_calculated = {}
 		@overview.each_pair do |category, content|
 			# remove weight 0 and bonus
 			@overview[category]['submits'] = @overview[category]['submits'].reject { |submit, weight| (weight == 0 || weight == 'bonus') }
 
 			# determine subgrades
+			@subgrades[category] = []
+			@show_calculated[category] = false
 			@overview[category]['submits'].each_pair do |submit, weight|
-				@subgrades += Settings.grading['grades'][submit]['subgrades'].keys if !Settings.grading['grades'][submit]['hide_subgrades']
-			end 
+				@subgrades[category] += Settings.grading['grades'][submit]['subgrades'].keys if !Settings.grading['grades'][submit]['hide_subgrades']
+				@show_calculated[category] = true if !Settings.grading['grades'][submit]['hide_calculated']
+			end
+			
+			# remove dupes
+			@subgrades[category] = @subgrades[category].uniq
 		end
-
-		# remove dupes
-		@subgrades = @subgrades.uniq
 
 		# convert grades to an easy-to-use format
 		@grades_by_pset = @grades.to_h { |item| [item.pset.name, item] }

--- a/app/helpers/grades_helper.rb
+++ b/app/helpers/grades_helper.rb
@@ -14,6 +14,10 @@ module GradesHelper
 		
 		return ""
 	end
+
+	def humanize_submit(submit)
+		return submit.humanize.gsub(/([^\d\s])(\d)/, '\1 \2')
+	end
 	
 	def translate_grade(grade)
 		return "error" if grade.nil? || grade < -1

--- a/app/helpers/grades_helper.rb
+++ b/app/helpers/grades_helper.rb
@@ -24,8 +24,9 @@ module GradesHelper
 
 	def translate_subgrade(grade)
 		return "" if grade.nil?
-		return "yes" if grade == -1 || grade.to_i == -1
+		return "yes" if grade == -1 && !grade.is_a?(Float)
 		return "no" if grade == 0
+		return grade.to_i.to_s if grade == grade.to_i
 		return grade.to_s
 	end
 	

--- a/app/views/home/_grades_overview.html.erb
+++ b/app/views/home/_grades_overview.html.erb
@@ -1,30 +1,29 @@
-<div class="card">
+<div id="overview" class="card">
 	<div class="card-body">
 		<h5 class="card-title"><%= t('overview') %></h5>
-		<table class="table table-sm table-responsive">
-			<%# Table header  %>
-			<tr>
-				<%# Assignment %>
-				<th><%= t('assignment') %></th>
-				<%# Subgrades  %>
-				<% @subgrades.each do |subgrade| %>
-					<th><%= subgrade.capitalize %></th>
-				<% end %>
-				<%# Final grade %>
-				<th>Grade</th>
-			</tr>
-			<% @overview.each_pair do |category, content| %>
-				<%# Create category heading. %>
+		<% @overview.each_pair do |category, content| %>
+			<h6><%= category.capitalize %></h6>
+			<table class="table table-sm table-responsive">
+				<%# Table header  %>
 				<tr>
-					<th colspan=<%= @subgrades.length + 2 %>><center><%= category.capitalize %></center></th>
+					<%# Assignment %>
+					<th></th>
+					<%# Subgrades  %>
+					<% @subgrades[category].each do |subgrade| %>
+						<th><%= subgrade.capitalize %></th>
+					<% end %>
+					<%# Final grade %>
+					<% if @show_calculated[category] %>
+						<th>Grade</th>
+					<% end %>
 				</tr>
 
 				<% content['submits'].each_pair do |submit, weight| %>
 					<%# Each submit within category %>
 					<tr>
 						<%# Submit name %>
-						<td><%= submit %></td>
-						<% @subgrades.each do |subgrade| %>
+						<th><%= humanize_submit(submit) %></th>
+						<% @subgrades[category].each do |subgrade| %>
 							<%# Print each subgrade if it exists for this grade, subgrades are not hidden, and the grade isn't unpublished. %>
 							<%# Else, print a dash. %>
 							<% if @grades_by_pset.key?(submit) && !Settings.grading['grades'][submit]['hide_subgrades'] && @grades_by_pset[submit].subgrades[subgrade] %>
@@ -33,17 +32,18 @@
 								<td>-</td>
 							<% end %>
 						<% end %>
-						<%# Print calculated grade for this submit if it is not unpublished or hidden. %>
-						<%# Else, print a dash. %>
-						<% if @grades_by_pset.key?(submit) && !Settings.grading['grades'][submit]['hide_calculated'] %>
-							<td><%= translate_grade(@grades_by_pset[submit].any_final_grade) %></td>
-						<% else %>
-							<td>-</td>
+						<% if @show_calculated[category] %>
+							<%# Print calculated grade for this submit if it is not unpublished or hidden. %>
+							<%# Else, print a dash. %>
+							<% if @grades_by_pset.key?(submit) && !Settings.grading['grades'][submit]['hide_calculated'] %>
+								<td><%= translate_grade(@grades_by_pset[submit].any_final_grade) %></td>
+							<% else %>
+								<td>-</td>
+							<% end %>
 						<% end %>
 					</tr>
 				<% end %>
-
-			<% end %>
-		</table>
+			</table>
+		<% end %>
 	</div>
 </div>

--- a/app/views/home/_grades_overview.html.erb
+++ b/app/views/home/_grades_overview.html.erb
@@ -1,0 +1,49 @@
+<div class="card">
+	<div class="card-body">
+		<h5 class="card-title"><%= t('overview') %></h5>
+		<table class="table table-sm table-responsive">
+			<%# Table header  %>
+			<tr>
+				<%# Assignment %>
+				<th><%= t('assignment') %></th>
+				<%# Subgrades  %>
+				<% @subgrades.each do |subgrade| %>
+					<th><%= subgrade.capitalize %></th>
+				<% end %>
+				<%# Final grade %>
+				<th>Grade</th>
+			</tr>
+			<% @overview.each_pair do |category, submits| %>
+				<%# Create category heading. %>
+				<tr>
+					<th colspan=<%= @subgrades.length + 2 %>><center><%= category.capitalize %></center></th>
+				</tr>
+
+				<% submits.each do |submit| %>
+					<%# Each submit within category %>
+					<tr>
+						<%# Submit name %>
+						<td><%= submit %></td>
+						<% @subgrades.each do |subgrade| %>
+							<%# Print each subgrade if it exists for this grade, subgrades are not hidden, and the grade isn't unpublished. %>
+							<%# Else, print a dash. %>
+							<% if @grades_by_pset.key?(submit) && !Settings.grading['grades'][submit]['hide_subgrades'] && @grades_by_pset[submit].subgrades[subgrade] %>
+								<td><%= translate_subgrade(@grades_by_pset[submit].subgrades[subgrade]) %></td>
+							<% else %>
+								<td>-</td>
+							<% end %>
+						<% end %>
+						<%# Print calculated grade for this submit if it is not unpublished or hidden. %>
+						<%# Else, print a dash. %>
+						<% if @grades_by_pset.key?(submit) && !Settings.grading['grades'][submit]['hide_calculated'] %>
+							<td><%= translate_grade(@grades_by_pset[submit].any_final_grade) %></td>
+						<% else %>
+							<td>-</td>
+						<% end %>
+					</tr>
+				<% end %>
+
+			<% end %>
+		</table>
+	</div>
+</div>

--- a/app/views/home/_grades_overview.html.erb
+++ b/app/views/home/_grades_overview.html.erb
@@ -13,13 +13,13 @@
 				<%# Final grade %>
 				<th>Grade</th>
 			</tr>
-			<% @overview.each_pair do |category, submits| %>
+			<% @overview.each_pair do |category, content| %>
 				<%# Create category heading. %>
 				<tr>
 					<th colspan=<%= @subgrades.length + 2 %>><center><%= category.capitalize %></center></th>
 				</tr>
 
-				<% submits.each do |submit| %>
+				<% content['submits'].each_pair do |submit, weight| %>
 					<%# Each submit within category %>
 					<tr>
 						<%# Submit name %>

--- a/app/views/home/submissions.html.erb
+++ b/app/views/home/submissions.html.erb
@@ -1,9 +1,11 @@
 <% if @items.present? %>
 <div id="timeline" class="row flex-xl-row-reverse">
-	<div class="col-xl-6 col-lg-12">
-		<%= render partial: "grades_overview" %>
-	</div>
-	<div class="col-xl-6 col-lg-12">
+	<% if !@overview.empty? %>
+		<div class="col-xl-6 col-lg-12">
+			<%= render partial: "grades_overview" %>
+		</div>
+	<% end %>
+	<div class="<%= 'col-xl-6' if !@overview.empty? %> col-lg-12">
 		<%= render partial: "items" %>
 	</div>
 </div>

--- a/app/views/home/submissions.html.erb
+++ b/app/views/home/submissions.html.erb
@@ -1,6 +1,9 @@
 <% if @items.present? %>
-<div id="timeline" class="row">
-	<div class="col">
+<div id="timeline" class="row flex-xl-row-reverse">
+	<div class="col-xl-6 col-lg-12">
+		<%= render partial: "grades_overview" %>
+	</div>
+	<div class="col-xl-6 col-lg-12">
 		<%= render partial: "items" %>
 	</div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,7 @@ en:
     you_submitted_ago: "You have submitted this problem set %{time} ago."
     see_submissions_page: "See the progress page for an overview."
     check_results: "Check results"
-    assignment: "Assignment"
-    overview: "Grades overview"
+    overview: "Results"
     weight: "weight"
     hands:
         staff_are_currently_available:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,6 +32,9 @@ en:
     you_submitted_ago: "You have submitted this problem set %{time} ago."
     see_submissions_page: "See the progress page for an overview."
     check_results: "Check results"
+    assignment: "Assignment"
+    overview: "Grades overview"
+    weight: "weight"
     hands:
         staff_are_currently_available:
             one: One member of staff is available

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -32,8 +32,7 @@ nl:
     you_submitted_ago: "Je hebt deze opdracht %{time} geleden ingestuurd."
     see_submissions_page: "Zie de voortgangspagina voor een overzicht."
     check_results: "Check-resultaten"
-    assignment: "Opdracht"
-    overview: "Overzicht scores"
+    overview: "Resultaten"
     weight: "weging"
     hands:
         staff_are_currently_available:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -32,6 +32,9 @@ nl:
     you_submitted_ago: "Je hebt deze opdracht %{time} geleden ingestuurd."
     see_submissions_page: "Zie de voortgangspagina voor een overzicht."
     check_results: "Check-resultaten"
+    assignment: "Opdracht"
+    overview: "Overzicht scores"
+    weight: "weging"
     hands:
         staff_are_currently_available:
             one: Eén medewerker beschikbaar


### PR DESCRIPTION
Resolves #352 

Adds an overview of the most important grades for students. This is set up in such a way that no additional settings are required.

![Screenshot 2019-11-13 at 11 50 30](https://user-images.githubusercontent.com/38955258/68757203-d2d80200-060b-11ea-917e-67fdc3bc9a21.png)

It shows any grades that are part of a category in the final grade calculation. Categories and grades with no weight and bonus assignments are ignored. Hidden or unpublished (sub)grades remain hidden. Titles for assignments, categories and subgrades are taken from the grading settings. Of course, I could add some settings for better control if that's preferred.

I did have to edit `translate_subgrade`, because otherwise it would show a late-score of `-1.0` as `yes`, which is very confusing. 